### PR TITLE
Remove NPM scope from package name for easier publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@paul-bonneville-labs/neemee-mcp-server",
+  "name": "neemee-mcp-server",
   "version": "1.0.0",
   "description": "MCP server for Neemee personal knowledge management system",
   "type": "module",


### PR DESCRIPTION
## Summary
- Changed package name from `@paul-bonneville-labs/neemee-mcp-server` to `neemee-mcp-server`
- Enables direct publishing to NPM public registry without requiring scope creation

## Test plan
- [x] Verify package name is available on NPM registry
- [x] Confirm TypeScript builds successfully
- [ ] Test npm publish command

🤖 Generated with [Claude Code](https://claude.ai/code)